### PR TITLE
0 ポイントになると購入フローのE2Eテストが失敗するのを修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       # see https://github.com/EC-CUBE/ec-cube2/issues/837
       working-directory: ec-cube
       run: rm e2e-tests/test/admin/total/total.test.ts
-    - name: Run to E2E testing
+    - name: Run to E2E testing(admin)
       working-directory: ec-cube
       env:
         HTTPS_PROXY: 'localhost:8090'
@@ -92,3 +92,11 @@ jobs:
         CI: 1
         FORCE_COLOR: 1
       run: yarn test:e2e e2e-tests/test/admin
+    - name: Run to E2E testing(front_login)
+      working-directory: ec-cube
+      env:
+        HTTPS_PROXY: 'localhost:8090'
+        HTTP_PROXY: 'localhost:8090'
+        CI: 1
+        FORCE_COLOR: 1
+      run: yarn test:e2e e2e-tests/test/front_login

--- a/tests/Fixture/Generator.php
+++ b/tests/Fixture/Generator.php
@@ -100,7 +100,7 @@ class Generator
             'birth' => $this->faker->dateTimeThisDecade()->format('Y-m-d H:i:s'),
             'status' => '2',     // 本会員
             'secret_key' => SC_Helper_Customer_Ex::sfGetUniqSecretKey(),
-            'point' => $this->faker->randomNumber()
+            'point' => $this->faker->numberBetween(1, 9999)
         ];
 
         return $this->objQuery->extractOnlyColsOf(


### PR DESCRIPTION
0ポイントだと先に進めなくなってしまう
https://github.com/EC-CUBE/ec-cube2/blob/12353521bb933cd5b3a182f12ec6674ce0d67e53/e2e-tests/pages/shopping/payment.page.ts#L72-L75