### PR TITLE
Fix: 会員の生年月日を現実的な範囲に変更

### DIFF
--- a/tests/Fixture/Generator.php
+++ b/tests/Fixture/Generator.php
@@ -92,7 +92,7 @@ class Generator
             'reminder' => $this->faker->numberBetween(1, 7),
             'reminder_answer' => $this->faker->word,
             'mailmaga_flg' => $this->faker->numberBetween(1, 2),
-            'birth' => $this->faker->dateTimeThisDecade()->format('Y-m-d H:i:s'),
+            'birth' => $this->faker->dateTimeBetween('-80 years', '-18 years')->format('Y-m-d H:i:s'),
             'status' => '2',     // 本会員
             'secret_key' => \SC_Helper_Customer_Ex::sfGetUniqSecretKey(),
             'point' => $this->faker->numberBetween(1, 9999),


### PR DESCRIPTION
## Summary
- `dateTimeThisDecade()` → `dateTimeBetween('-80 years', '-18 years')` に変更
- 直近10年（0〜6歳）ではなく、18〜80歳の現実的な生年月日を生成するようにした

## 背景
`dateTimeThisDecade()` は2020年〜現在の日付を生成するため、生年月日として非現実的な値（0〜6歳）になっていた。
これにより EC-CUBE 2 の売上集計 > 年代別集計で、MySQL の `BIGINT UNSIGNED value is out of range` エラーが発生する場合があった。

- `create_date` と `order_birth` が同年
- `RIGHT(col, 5)` の比較（datetime の MM:SS 部分）が TRUE になるケース
- `YEAR差 0 - 1 = -1` → unsigned 演算でオーバーフロー

See: https://github.com/EC-CUBE/ec-cube2/pull/1350

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * テストデータの生成処理を更新しました。顧客の生年月日のダミーデータ生成ロジックを変更し、より広い年齢範囲（18～80歳）をカバーするようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->